### PR TITLE
#28133 properly display unicode chars in app windows and Shotgun menu

### DIFF
--- a/plugins/shotgun/Application/Plugins/menu.py
+++ b/plugins/shotgun/Application/Plugins/menu.py
@@ -123,7 +123,9 @@ class ShotgunMenu(object):
         """
         Add the named sub-menu.
         """
-        sub_menu = ShotgunMenu(self._si_AddSubMenu(name), self._name_generator)
+        # the menu name should be a unicode object so we cast it to support when, for example, 
+        # the context contains info with non-ascii characters
+        sub_menu = ShotgunMenu(self._si_AddSubMenu(name.decode("utf-8")), self._name_generator)
         self._sub_menus.append(sub_menu)
         return sub_menu
 

--- a/python/tk_softimage/menu_generation.py
+++ b/python/tk_softimage/menu_generation.py
@@ -103,7 +103,9 @@ class MenuGenerator(object):
         ctx_name = str(ctx)
 
         # create the sub menu object
-        ctx_menu = self._menu_handle.AddSubMenu(ctx_name)
+        # the label expects a unicode object so we cast it to support when the context may 
+        # contain info with non-ascii character
+        ctx_menu = self._menu_handle.AddSubMenu(ctx_name.decode("utf-8"))
         ctx_menu.AddCallbackItem("Jump to Shotgun", lambda: self._jump_to_sg(self._menu_handle))
         ctx_menu.AddCallbackItem("Jump to File System", self._jump_to_fs)
 

--- a/python/tk_softimage/menu_generation.py
+++ b/python/tk_softimage/menu_generation.py
@@ -103,9 +103,7 @@ class MenuGenerator(object):
         ctx_name = str(ctx)
 
         # create the sub menu object
-        # the label expects a unicode object so we cast it to support when the context may 
-        # contain info with non-ascii character
-        ctx_menu = self._menu_handle.AddSubMenu(ctx_name.decode("utf-8"))
+        ctx_menu = self._menu_handle.AddSubMenu(ctx_name)
         ctx_menu.AddCallbackItem("Jump to Shotgun", lambda: self._jump_to_sg(self._menu_handle))
         ctx_menu.AddCallbackItem("Jump to File System", self._jump_to_fs)
 


### PR DESCRIPTION
Set codec to `utf-8` so when unicode characters are used in fields that get displayed in an app UI, they are now correctly displayed as the intended characters rather than incoherent glyphs.

Cast the menu labels to unicode to preserve non-ascii text. Pymel expects a unicode object to be passed in to create the menu label but previously we were sending it as a string. When the Toolkit context contains non-ascii characters, for example if an Asset name is in Japanese, this caused garbled characters to display in the menu. By casting the context string as unicode, any non-ascii characters will be preserved in the menu.

Also fixes warning message for 2013 on Linux