### PR TITLE
33062 Adds a call to log a user metric for the DCC version

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -65,7 +65,11 @@ class SoftimageEngine(Engine):
                 
             self.log_warning(msg)
 
-        self.log_user_attribute_metric("Softimage version", version_str)
+        try:
+            self.log_user_attribute_metric("Softimage version", version_str)
+        except:
+            # ignore all errors. ex: using a core that doesn't support metrics
+            pass
             
         # Set the Softimage project based on config
         self._set_project()

--- a/engine.py
+++ b/engine.py
@@ -64,6 +64,8 @@ class SoftimageEngine(Engine):
                 os.environ["SGTK_SOFTIMAGE_VERSION_WARNING_SHOWN"] = "1"
                 
             self.log_warning(msg)
+
+        self.log_user_attribute_metric("Softimage version", version_str)
             
         # Set the Softimage project based on config
         self._set_project()

--- a/info.yml
+++ b/info.yml
@@ -48,8 +48,6 @@ description: "Shotgun Pipeline Toolkit Integration in Softimage"
 requires_shotgun_version:
 requires_core_version: "v0.14.56"
 
-# XXX will require core version with metrics logging
- 
 # the frameworks required to run this app
 frameworks:
     - {"name": "tk-framework-softimageqt", "version": "v1.0.1"}

--- a/info.yml
+++ b/info.yml
@@ -47,6 +47,8 @@ description: "Shotgun Pipeline Toolkit Integration in Softimage"
 # Required minimum versions for this item to run
 requires_shotgun_version:
 requires_core_version: "v0.14.56"
+
+# XXX will require core version with metrics logging
  
 # the frameworks required to run this app
 frameworks:


### PR DESCRIPTION
The call logs the metric internally and ignores any errors. This prevents the need to force the engine's users to update to a new core that supports metrics. When a supported core is updated, the metric will be logged.